### PR TITLE
Fix spec error

### DIFF
--- a/spec/ruby-block-spec.coffee
+++ b/spec/ruby-block-spec.coffee
@@ -4,17 +4,17 @@ describe "RubyBlock", ->
   [workspaceElement, editor, editorElement, markers, lineNumbers, rubyBlockElement, bottomPanels] =  []
 
   beforeEach ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
+
     waitsForPromise -> atom.packages.activatePackage('language-ruby')
-    waitsForPromise -> atom.workspace.open('test.rb')  
+    waitsForPromise -> atom.workspace.open('test.rb')
     waitsForPromise ->
       atom.packages.activatePackage('ruby-block').then (pkg) ->
         rubyBlock = pkg.mainModule
         atom.config.set 'ruby-block.highlightLineNumber', true
-        
+
     runs ->
-      workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
-      
       editor = atom.workspace.getActiveTextEditor()
       editorElement = atom.views.getView(editor)
 
@@ -25,17 +25,17 @@ describe "RubyBlock", ->
       lineNumbers = editorElement.shadowRoot.querySelectorAll('.line-number.ruby-block-highlight')
       rubyBlockElement = workspaceElement.querySelector('.panel-bottom .ruby-block')
       bottomPanels = atom.workspace.getBottomPanels()
-      
+
     it 'highlights line', ->
       expect(markers.length).toBe 1
-      
+
     it 'highlights gutter', ->
       expect(lineNumbers.length).toBe 1
-      
+
     it 'shows view in bottom panel', ->
       expect(rubyBlockElement).toExist
       expect(bottomPanels[0].isVisible()).toBe true
-      
+
   describe "when cursor is not on the 'end'", ->
     beforeEach ->
       editor.setCursorBufferPosition [4, 0]
@@ -43,14 +43,13 @@ describe "RubyBlock", ->
       lineNumbers = editorElement.shadowRoot.querySelectorAll('.line-number.ruby-block-highlight')
       rubyBlockElement = workspaceElement.querySelector('.panel-bottom .ruby-block')
       bottomPanels = atom.workspace.getBottomPanels()
-    
+
     it "doesn't highlight line", ->
       expect(markers.length).toBe 0
-  
+
     it "doesn't highlight gutter", ->
       expect(lineNumbers.length).toBe 0
-    
+
     it 'shows view in bottom panel', ->
       expect(rubyBlockElement).toExist
       expect(bottomPanels[0].isVisible()).toBe false
-    


### PR DESCRIPTION
```
Error deactivating package 'ruby-block' Error: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
  at Error (native)
  at atom-panel-container.PanelContainerElement.panelRemoved (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/panel-container-element.js:63:19)
  at Emitter.module.exports.Emitter.emit (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:82:11)
  at PanelContainer.module.exports.PanelContainer.panelDestroyed (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/panel-container.js:93:29)
  at Emitter.module.exports.Emitter.emit (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:82:11)
  at Panel.module.exports.Panel.destroy (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/panel.js:25:20)
  at Object.module.exports.RubyBlock.deactivate (/Users/aki/src/github.com/aki77/ruby-block/lib/ruby-block.coffee:77:17)
  at Package.module.exports.Package.deactivate (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/package.js:633:21)
  at PackageManager.module.exports.PackageManager.deactivatePackage (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/package-manager.js:486:12)
  at /opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/package-manager.js:471:19
  at Config.module.exports.Config.transact (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/config.js:311:16)
  at PackageManager.module.exports.PackageManager.deactivatePackages (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/package-manager.js:465:19)
  at [object Object].<anonymous> (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/spec/spec-helper.js:226:19)
  at [object Object].jasmine.Block.execute (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/vendor/jasmine.js:1070:17)
  at [object Object].jasmine.Queue.next_ (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/vendor/jasmine.js:2102:31)
  at /opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/vendor/jasmine.js:2092:18
/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/src/package.js:638 module.exports.Package.deactivate
```
