### PR TITLE
Update readme style.less example for atom 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Highlighting line and bottom panel are enable by default.
 ## Overwriting default styles
 If you want to change default highliting color, just add styles with preference for color like below into `styles.less`.
 ```less
-:host, atom-text-editor, atom-text-editor::shadow {
+:host, atom-text-editor, atom-text-editor.editor {
   .line-number.ruby-block-highlight {
     background-color: red;
   }


### PR DESCRIPTION
The existing README recommendation to edit style.less brings up a deprecation warning in the latest version of Atom, so I fixed it according to their warning's advice. After reloading Atom with this edit there is no warning and plugin is still working fine.

Deprecation warning is copied below:

"Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

:host .line-number.ruby-block-highlight, atom-text-editor .line-number.ruby-block-highlight, atom-text-editor::shadow .line-number.ruby-block-highlight => :host .line-number.ruby-block-highlight, atom-text-editor .line-number.ruby-block-highlight, atom-text-editor.editor .line-number.ruby-block-highlight
:host .highlights .ruby-block-highlight .region, atom-text-editor .highlights .ruby-block-highlight .region, atom-text-editor::shadow .highlights .ruby-block-highlight .region => :host .highlights .ruby-block-highlight .region, atom-text-editor .highlights .ruby-block-highlight .region, atom-text-editor.editor .highlights .ruby-block-highlight .region
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible."